### PR TITLE
Require first name and last name for new users

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -72,4 +72,16 @@ Rails.configuration.to_prepare do
 
   end
 
+  User.class_eval do
+
+    validates :name,
+              :on => :create,
+              :format => {
+                :with => /\s/,
+                :message => _("Please enter your full name"),
+                :allow_blank => true
+              }
+
+  end
+
 end

--- a/spec/model_patches_spec.rb
+++ b/spec/model_patches_spec.rb
@@ -92,3 +92,32 @@ describe OutgoingMessage, 'when patched by the asktheeu-theme' do
   end
 
 end
+
+describe User, 'when patched by the asktheeu-theme' do
+
+  it 'is valid with a first name and last name' do
+    user = User.new(:name => "Test User")
+    user.valid?
+    expect(user.errors[:name].count).to eq(0)
+  end
+
+  it 'is invalid with just a first name' do
+    user = User.new(:name => "Test")
+    user.valid?
+    expect(user.errors[:name].count).to eq(1)
+  end
+
+  it 'provides a message asking for a full name if just one name is entered' do
+    user = User.new(:name => "Test")
+    user.valid?
+    expect(user.errors[:name]).to eq ["Please enter your full name"]
+  end
+
+  it 'still allows pre-existing users to update their info' do
+    old_user = FactoryGirl.build(:user, :name => "SingleName")
+    old_user.save(:validate => false) # save the invalid record!
+    old_user.about_me = "hi, I am a new test user!"
+    expect{ old_user.save! }.not_to raise_error
+  end
+
+end


### PR DESCRIPTION
The validation is only run when new user accounts are created, otherwise existing users won't be able to update their information (the update will fail with the error `Validation failed: User|Name Please enter your full name`) - as there is currently no way for a user to update their name.

There are currently 628 users who have registered with a single name on the site (unless more joined since me looking it up this morning).

Closes #33 