### PR TITLE
Super simple social sharing on successful request page

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -393,7 +393,8 @@ a.link_button_green_large {
   margin:1em 0;
   padding: 1.5em;
 
-  p:first-child {
+  p:first-child,
+  h1:first-child {
     margin-top: 0;
   }
 
@@ -407,7 +408,7 @@ a.link_button_green_large {
 }
 
 #notice, #request_header_text {
-  background-color: desaturate(lighten($notice-color, 30%),10%);
+  background-color: mix($notice-color, #f3f3f3, 12%);
   border-color: $notice-color;
 }
 
@@ -420,6 +421,15 @@ a.link_button_green_large {
 .undescribed_requests {
   background-color: desaturate(lighten($action-color, 30%),10%);
   border-color: $action-color;
+}
+
+.share-link {
+  margin-right: 0.4em;
+}
+
+.annotation-reminder {
+  margin-top: 1.5em;
+  max-width: 34em;
 }
 
 

--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -14,7 +14,7 @@
                         :url => request.url,
                         :via => AlaveteliConfiguration.twitter_username,
                         :text => "'#{ @info_request.title }'",
-                        :related => _('mySocietyIntl:Helping people set ' \
+                        :related => _('mySociety:Helping people set ' \
                                         'up sites like {{site_name}} ' \
                                         'all over the world',
                                       :site_name => site_name),

--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -4,7 +4,7 @@
   <%= _("We're glad you got all the information that you wanted.") %>
 </p>
 
-<h2><%= _("Share your request") %></h2>
+<h3><%= _("Let other people know what you’ve found out") %></h3>
 
 <%= link_to image_tag("next-step-twitter.png",
                       :alt => _("Tweet it"),

--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -1,0 +1,56 @@
+<h1><%= _('Great news!') %></h1>
+
+<p class="subtitle">
+  <%= _("We're glad you got all the information that you wanted.") %>
+</p>
+
+<h2><%= _("Share your request") %></h2>
+
+<%= link_to image_tag("next-step-twitter.png",
+                      :alt => _("Tweet it"),
+                      :width => "120",
+                      :height => "37"),
+                      "https://twitter.com/intent/tweet?" << {
+                        :url => request.url,
+                        :via => AlaveteliConfiguration.twitter_username,
+                        :text => "'#{ @info_request.title }'",
+                        :related => _('mySocietyIntl:Helping people set ' \
+                                        'up sites like {{site_name}} ' \
+                                        'all over the world',
+                                      :site_name => site_name),
+                      }.to_query, :class => 'share-link',
+                                  :onclick => track_analytics_event(
+                                    AnalyticsEvent::Category::OUTBOUND,
+                                    AnalyticsEvent::Action::TWITTER_EXIT,
+                                    :label => "Share Request") %>
+
+
+<%= link_to image_tag("next-step-facebook.png",
+                      :alt => _("Share on Facebook"),
+                      :width => "120",
+                      :height => "37"),
+                      "https://www.facebook.com/sharer/sharer.php?" << {
+                        :u => request.url
+                      }.to_query, :class => 'share-link',
+                                  :onclick => track_analytics_event(
+                                    AnalyticsEvent::Category::OUTBOUND,
+                                    AnalyticsEvent::Action::FACEBOOK_EXIT,
+                                    :label => "Share Request") %>
+
+
+<% if AlaveteliConfiguration.enable_annotations %>
+  <p class="annotation-reminder">
+    <%= _('If you write about this request ' \
+          '(for example in a forum or a blog) ' \
+          'please link to this page, and <a href="{{url}}">add an ' \
+          'annotation</a> below telling people ' \
+          'about your writing.',
+          :url => new_comment_url(:url_title => @info_request.url_title).html_safe) %>
+  </p>
+<% else %>
+  <p class="annotation-reminder">
+    <%= _('If you write about this request ' \
+          '(for example in a forum or a blog) ' \
+          'please link to this page.') %>
+  </p>
+<% end %>


### PR DESCRIPTION
Just added social sharing buttons in the simplest way possible, taking most of my cues from @wrightmartin’s recent [similar changes](https://github.com/mysociety/whatdotheyknow-theme/pull/318/) to WhatDoTheyKnow.

Fixes mysociety/alaveteli#3268.

Part of mysociety/alaveteli-experiments#26.

✋ Deployment note: this pr references `AnalyticsEvents` added in da00491754a25f7e8c5d2754ba555a8fec678b46 - this hasn't made it to `master` yet. 

![screen shot 2016-06-02 at 16 30 34](https://cloud.githubusercontent.com/assets/739624/15750706/5f596272-28df-11e6-90ea-babe98115aaf.png)
