### PR TITLE
Cache blog section of homepage separately

### DIFF
--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
 
   # We want to start by showing the public bodies categories and search only
   match '/body/' => 'public_body#index', :as => "body_index"
+
+  # Cached version of blog
+  match '/blog' => 'general#cached_blog', :as => :blog
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -18,12 +18,7 @@ Rails.configuration.to_prepare do
                              :title => _('Successful requests'),
                              :has_json => true } ]
 
-      begin
-        blog
-      rescue
-        @blog_items = []
-        @twitter_user = MySociety::Config.get('TWITTER_USERNAME', '')
-      end
+      blog_cache("latest_blog_posts-#{@locale}")
 
       @top_requests = if params[:e] == "52"
         InfoRequest.where(:described_state => "successful").
@@ -40,6 +35,52 @@ Rails.configuration.to_prepare do
       if @top_requests.empty?
         @top_requests = InfoRequest.top_requests.limit(2)
       end
+    end
+
+    private
+
+    def blog_cache(cache_key, expires=4.hours)
+      # nothing to do here, call the blog code and return
+      return blog unless AlaveteliConfiguration::cache_fragments
+
+      # read in the last timestamp
+      updated = read_fragment("#{cache_key}-lastupdated")
+
+      # construct the fragment key
+      @fragment_key = "#{cache_key}-#{updated}"
+
+      # if the fragment is unreadable or has reached expiry
+      # attempt to pull in the blog feed
+      if updated.nil? || !fragment_exist?(@fragment_key) ||
+         Time.now > (Time.parse(updated) + expires)
+        # keep a note of the old key
+        old_key = @fragment_key.dup
+
+        # prepare a new timestamp and fragment key
+        updated = create_timestamp
+        @fragment_key = "#{cache_key}-#{updated}"
+
+        logger.info "attempting to pull in the feed"
+        blog
+
+        if @blog_items.empty?
+          # attempt to write the previous fragment to our new cache
+          fragment = read_fragment(old_key)
+          if fragment
+            logger.warn "Writing old blog fragment (#{old_key}) to " \
+                        "current cache (#{@fragment_key}) due to feed " \
+                        "error or timeout."
+            write_fragment(@fragment_key, fragment)
+          end
+        end
+
+        # store the new timestamp
+        write_fragment("#{cache_key}-lastupdated", updated)
+      end
+    end
+
+    def create_timestamp(time=Time.now)
+      time.strftime('%Y%m%d-%H:%M:%S')
     end
   end
 

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -37,6 +37,11 @@ Rails.configuration.to_prepare do
       end
     end
 
+    def cached_blog
+      blog_cache("blog_posts-#{@locale}")
+      render :action => 'blog'
+    end
+
     private
 
     def blog_cache(cache_key, expires=4.hours)

--- a/lib/helper_patches.rb
+++ b/lib/helper_patches.rb
@@ -45,4 +45,4 @@ Rails.configuration.to_prepare do
 
   end
 
- end
+end

--- a/lib/views/general/blog.html.erb
+++ b/lib/views/general/blog.html.erb
@@ -7,6 +7,7 @@
 
 <div id="main_content">
 
+  <% cache_if_caching_fragments(@fragment_key) do %>
   <div id="blog">
     <% @blog_items.in_groups_of(4, false) do |group| %>
       <div class="blog__container">
@@ -25,4 +26,5 @@
       </div>
     <% end %>
   </div>
+  <% end %>
 </div>

--- a/lib/views/general/frontpage.html.erb
+++ b/lib/views/general/frontpage.html.erb
@@ -44,7 +44,6 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
 <% end %>
 
 <% cache_if_caching_fragments(@fragment_key) do %>
-  <% logger.info "RENDERING BLOG IN VIEW" %>
   <div class="frontpage__tertiary">
 
     <div class="wrapper">

--- a/lib/views/general/frontpage.html.erb
+++ b/lib/views/general/frontpage.html.erb
@@ -41,6 +41,10 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
   </div><%# close div#content %>
   </div><%# close div#wrapper %>
 
+<% end %>
+
+<% cache_if_caching_fragments(@fragment_key) do %>
+  <% logger.info "RENDERING BLOG IN VIEW" %>
   <div class="frontpage__tertiary">
 
     <div class="wrapper">

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -1,0 +1,211 @@
+# -*- encoding : utf-8 -*-
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'asktheeu-theme'
+require File.expand_path(File.join(File.dirname(__FILE__),
+                         '..','..','..','..', '..', 'spec','spec_helper'))
+
+describe GeneralController, "when patched by the asktheeu-theme" do
+
+  describe "caching blog content" do
+
+    before do
+      allow(controller).to receive(:blog).and_return("")
+    end
+
+    context "creating the timestamp" do
+
+      it "returns a string" do
+        expect(controller.send(:create_timestamp)).to be_a(String)
+      end
+
+      it "does not contain spaces" do
+        expect(controller.send(:create_timestamp)).not_to include(" ")
+      end
+
+      it "can be read back correctly" do
+        time = Time.parse("2016-08-01 09:29:16")
+        timestamp = controller.send(:create_timestamp, time)
+        expect(Time.parse(timestamp)).to eq(time)
+      end
+
+    end
+
+    context "caching is disabled" do
+
+      before do
+        allow(AlaveteliConfiguration).to receive(:cache_fragments).
+          and_return(false)
+      end
+
+      it "does not attempt to read from the cache" do
+        expect(controller).not_to receive(:read_fragment)
+        controller.send(:blog_cache, "test", 1.minute)
+      end
+
+      it "calls the blog controller action" do
+        expect(controller).to receive(:blog)
+        controller.send(:blog_cache, "test", 1.minute)
+      end
+
+    end
+
+    context "the cache is empty" do
+
+      before do
+        allow(AlaveteliConfiguration).to receive(:cache_fragments).
+          and_return(true)
+        allow(controller).to receive(:read_fragment).with("test-lastupdated").
+          and_return(nil)
+        allow(controller).to receive(:write_fragment)
+      end
+
+      context "the blog is available" do
+
+        before do
+          controller.instance_variable_set(:@blog_items, ["content"])
+        end
+
+        it "calls the blog controller action" do
+          expect(controller).to receive(:blog)
+          controller.send(:blog_cache, "test", 10.minutes)
+        end
+
+        it "sets the cache that holds the last updated timestamp" do
+          expect(controller).to receive(:write_fragment).
+            with("test-lastupdated", anything)
+          controller.send(:blog_cache, "test", 10.minutes)
+        end
+
+      end
+
+      context "the blog is not available" do
+
+        before do
+          controller.instance_variable_set(:@blog_items, [])
+          allow(controller).to receive(:read_fragment).with("test-lastupdated").
+            and_return(nil)
+          allow(controller).to receive(:read_fragment).with("test-").
+            and_return(nil)
+        end
+
+        it "calls the blog controller action" do
+          expect(controller).to receive(:blog)
+          controller.send(:blog_cache, "test", 10.minutes)
+        end
+
+        it "sets the cache that holds the last updated timestamp" do
+          expect(controller).to receive(:write_fragment).
+            with("test-lastupdated", anything)
+          controller.send(:blog_cache, "test", 10.minutes)
+        end
+
+        it "does not attempt to write new fragment if there isn't an old one" do
+          allow(controller).to receive(:read_fragment).with("test-").
+            and_return(nil)
+          expect(controller).to receive(:write_fragment).once
+          controller.send(:blog_cache, "test", 10.minutes)
+        end
+
+      end
+
+    end
+
+    context "there is cached content" do
+      let(:updated) { "#{Time.now - 3.minutes}"}
+
+      before do
+        allow(AlaveteliConfiguration).to receive(:cache_fragments).
+          and_return(true)
+        allow(controller).to receive(:write_fragment)
+        allow(controller).to receive(:read_fragment).with("test-lastupdated").
+          and_return(updated)
+        allow(controller).to receive(:fragment_exist?).with("test-#{updated}").
+          and_return(true)
+      end
+
+      context "the cache is fresh" do
+
+        it "does not call the blog controller action" do
+          expect(controller).to_not receive(:blog)
+          controller.send(:blog_cache, "test", 4.minutes)
+        end
+
+        it "does not set the cache that holds the last updated timestamp" do
+          expect(controller).to_not receive(:write_fragment).
+            with("test-lastupdated", anything)
+          controller.send(:blog_cache, "test", 4.minutes)
+        end
+
+        context "but the content fragment can not be read" do
+
+          it "calls the blog controller action" do
+            controller.instance_variable_set(:@blog_items, ["content"])
+            allow(controller).to receive(:fragment_exist?).
+              with("test-#{updated}").and_return(false)
+            allow(controller).to receive(:read_fragment).
+              and_return(nil)
+            expect(controller).to receive(:blog)
+            controller.send(:blog_cache, "test", 4.minutes)
+          end
+
+        end
+
+      end
+
+      context "the cache is stale" do
+
+        context "the blog is not available" do
+
+          before do
+            controller.instance_variable_set(:@blog_items, [])
+            allow(controller).to receive(:read_fragment).with("test-#{updated}").
+              and_return("old fragment")
+          end
+
+          it "calls the blog controller action" do
+            expect(controller).to receive(:blog)
+            controller.send(:blog_cache, "test", 2.minutes)
+          end
+
+          it "sets the cache that holds the last updated timestamp" do
+            expect(controller).to receive(:write_fragment).
+              with("test-lastupdated", anything)
+            controller.send(:blog_cache, "test", 2.minutes)
+          end
+
+          it "writes out the previous fragment if there is one" do
+            allow(controller).to receive(:write_fragment).
+              with("test-lastupdated", anything)
+            expect(controller).to receive(:write_fragment).
+              with(anything, "old fragment")
+            controller.send(:blog_cache, "test", 2.minutes)
+          end
+
+        end
+
+        context "the blog is available" do
+
+          before do
+            controller.instance_variable_set(:@blog_items, ["content"])
+          end
+
+          it "calls the blog controller action" do
+            expect(controller).to receive(:blog)
+            controller.send(:blog_cache, "test", 2.minutes)
+          end
+
+          it "sets the cache that holds the last updated timestamp" do
+            expect(controller).to receive(:write_fragment).
+              with("test-lastupdated", anything)
+            controller.send(:blog_cache, "test", 2.minutes)
+          end
+
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Cache the blog posts on the homepage separately from the rest of the template with a longer expiry time (currently set to 4 hours).

Introduces a new helper method `cache_if_caching_fragments_conditional` which takes one more param than the standard `cache_if_caching_fragments` to prevent the fragment being cached under certain conditions (in this case if the `@blog_items` is empty, indicating that the call to the blog feed failed). If the cache is in effect, the call to the blog feed is not made.

A different approach could be to always try to read in the blog feed and have the controller overwrite the cached fragment if it succeeded (or, if preferred, if it succeeded and the content had changed). This would require creating a new partial for the homepage blog section.

Aside: the call to the inherited `blog` controller action can be simplified in any case as it no longer raises an error when the feed times out.

Closes #41 