### PR TITLE
Make it clearer that "internal review" is a "confirmatory application"

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -43,6 +43,27 @@ Rails.configuration.to_prepare do
 
   end
 
+  OutgoingMessage::Template::InternalReview.class_eval do
+
+    # Override the default template text
+    def letter(replacements = {})
+      msg = _("\n\nPlease pass this on to the person who reviews " \
+              "confirmatory applications.\n\n" \
+              "I am filing the following confirmatory application with " \
+              "regards to my access to documents request " \
+              "'{{info_request_title}}'.",
+              replacements)
+      msg += "\n\n\n\n"
+      msg += " [ #{ self.class.details_placeholder } ] "
+      msg += "\n\n\n\n"
+      msg += _("A full history of my request and all correspondence " \
+               "is available on the Internet at this address: {{url}}",
+               replacements)
+      msg
+    end
+
+  end
+
   OutgoingMessage.class_eval do
 
     # Add intro paragraph to new request template

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -96,6 +96,22 @@ Rails.configuration.to_prepare do
 
   end
 
+  OutgoingMailer.class_eval do
+
+    # Use "confirmatory application" wording instead of "internal review"
+    # in the email subject line to the authority
+    def self.subject_for_followup(info_request, outgoing_message, options = {})
+      if outgoing_message.what_doing == 'internal_review'
+        _("Confirmatory application for {{email_subject}}",
+          :email_subject => info_request.email_subject_request(:html => options[:html]))
+      else
+        info_request.email_subject_followup(:incoming_message => outgoing_message.incoming_message_followup,
+                                            :html => options[:html])
+      end
+    end
+
+  end
+
   # Disable funcionality to let users of the site act on behalf of the public
   # body, since we aren't sure right now this is safe enough
   PublicBody.class_eval do

--- a/lib/views/request/_after_actions.html.erb
+++ b/lib/views/request/_after_actions.html.erb
@@ -1,0 +1,64 @@
+<div id="after_actions" class="after_actions">
+  <h2><%= _('Things to do with this request') %></h2>
+
+  <div id="anyone_actions" class="anyone_actions">
+    <strong><%= _('Anyone:') %></strong>
+
+    <ul>
+      <% if AlaveteliConfiguration.enable_annotations && @info_request.comments_allowed? %>
+        <li>
+          <%= raw(_('<a href="{{url}}">Add an annotation</a> (to help the ' \
+                      'requester or others)',
+                    :url => new_comment_url(:url_title => @info_request.url_title).html_safe)) %>
+        </li>
+      <% end %>
+
+      <% if @old_unclassified %>
+        <li>
+          <%= link_to _('Update the status of this request'), '#describe_state_form_1' %>
+        </li>
+      <% end %>
+
+      <li>
+        <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => @info_request.url_title) %>
+      </li>
+    </ul>
+  </div>
+
+  <% if ! @info_request.is_external? %>
+    <div id="owner_actions" class="owner_actions">
+      <strong><%= _('{{info_request_user_name}} only:',:info_request_user_name=>h(@info_request.user_name)) %></strong>
+
+      <ul>
+        <li>
+          <% if @last_response.nil? %>
+            <%= link_to _("Send a followup"), new_request_followup_path(:request_id => @info_request.id, :anchor => 'followup') %>
+          <% else %>
+            <%= link_to _("Write a reply"), new_request_incoming_followup_path(:request_id => @info_request.id, :incoming_message_id => @last_response.id, :anchor => 'followup') %>
+          <% end %>
+        </li>
+
+        <% if !@old_unclassified %>
+          <li>
+            <%= link_to _("Update the status of this request"), request_path(@info_request, :update_status => 1) %>
+          </li>
+        <% end %>
+
+        <li>
+          <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => @info_request.id, :internal_review => '1', :anchor => 'followup') %>
+        </li>
+      </ul>
+    </div>
+  <% end %>
+
+  <div id="public_body_actions" class="public_body_actions">
+    <strong><%= _('{{public_body_name}} only:',:public_body_name=>h(@info_request.public_body.name) ) %> </strong>
+
+    <ul>
+      <li>
+        <%= link_to _("Respond to request"), upload_response_path(:url_title => @info_request.url_title) %>
+      </li>
+    </ul>
+  </div>
+</div>
+

--- a/lib/views/request/_after_actions.html.erb
+++ b/lib/views/request/_after_actions.html.erb
@@ -45,7 +45,7 @@
         <% end %>
 
         <li>
-          <%= link_to _("Request an internal review"), new_request_followup_path(:request_id => @info_request.id, :internal_review => '1', :anchor => 'followup') %>
+          <%= link_to _("Request an internal review (also called a confirmatory application)"), new_request_followup_path(:request_id => @info_request.id, :internal_review => '1', :anchor => 'followup') %>
         </li>
       </ul>
     </div>

--- a/locale-theme/app.pot
+++ b/locale-theme/app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: version 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-31 15:55+0000\n"
+"POT-Creation-Date: 2016-09-26 03:15-0700\n"
 "PO-Revision-Date: 2016-01-08 14:17+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+msgstr ""
+
+msgid "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+msgstr ""
+
+msgid "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
+msgstr ""
 
 msgid "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
 msgstr ""
@@ -28,6 +37,12 @@ msgid "About"
 msgstr ""
 
 msgid "Access Info"
+msgstr ""
+
+msgid "An access to documents request"
+msgstr ""
+
+msgid "Anyone:"
 msgstr ""
 
 msgid "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
@@ -54,7 +69,13 @@ msgstr ""
 msgid "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 msgstr ""
 
+msgid "Confirmatory application for {{email_subject}}"
+msgstr ""
+
 msgid "Contact"
+msgstr ""
+
+msgid "Download a zip file of all correspondence"
 msgstr ""
 
 msgid "Error message"
@@ -72,6 +93,9 @@ msgstr ""
 msgid "Gone Postal"
 msgstr ""
 
+msgid "Great news!"
+msgstr ""
+
 msgid "Homepage header photo © European Union 2014 - European Parliament"
 msgstr ""
 
@@ -84,6 +108,12 @@ msgstr ""
 msgid "If you believe this request is not suitable, you can report it for attention by the site administrators"
 msgstr ""
 
+msgid "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+msgstr ""
+
+msgid "If you write about this request (for example in a forum or a blog) please link to this page."
+msgstr ""
+
 msgid "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 msgstr ""
 
@@ -91,6 +121,9 @@ msgid "Internal Review"
 msgstr ""
 
 msgid "Latest news and campaigns"
+msgstr ""
+
+msgid "Let other people know what you’ve found out"
 msgstr ""
 
 msgid "Make a request"
@@ -120,6 +153,9 @@ msgstr ""
 msgid "Partial Success"
 msgstr ""
 
+msgid "Please enter your full name"
+msgstr ""
+
 msgid "Please kindly use this email address for all replies to this request: {{email}}"
 msgstr ""
 
@@ -129,16 +165,25 @@ msgstr ""
 msgid "Referred."
 msgstr ""
 
+msgid "Regulation 1049/2001"
+msgstr ""
+
 msgid "Rejected"
 msgstr ""
 
 msgid "Report this request"
 msgstr ""
 
+msgid "Request an internal review (also called a confirmatory application)"
+msgstr ""
+
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr ""
 
 msgid "Requires Admin"
+msgstr ""
+
+msgid "Respond to request"
 msgstr ""
 
 msgid "SUPPORT THE CAMPAIGNS"
@@ -150,16 +195,28 @@ msgstr ""
 msgid "See all"
 msgstr ""
 
+msgid "Send a followup"
+msgstr ""
+
 msgid "Send a request"
 msgstr ""
 
+msgid "Share on Facebook"
+msgstr ""
+
 msgid "Similar requests"
+msgstr ""
+
+msgid "Submit Search"
 msgstr ""
 
 msgid "Successful"
 msgstr ""
 
 msgid "Successful requests"
+msgstr ""
+
+msgid "Things to do with this request"
 msgstr ""
 
 msgid "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
@@ -186,6 +243,9 @@ msgstr ""
 msgid "Transferred."
 msgstr ""
 
+msgid "Tweet it"
+msgstr ""
+
 msgid "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 msgstr ""
 
@@ -196,6 +256,9 @@ msgid "Unknown Status"
 msgstr ""
 
 msgid "Unsuitable?"
+msgstr ""
+
+msgid "Update the status of this request"
 msgstr ""
 
 msgid "User Withdrawn"
@@ -210,10 +273,22 @@ msgstr ""
 msgid "Waiting Response"
 msgstr ""
 
+msgid "We're glad you got all the information that you wanted."
+msgstr ""
+
 msgid "Which EU body?"
 msgstr ""
 
-msgid "access to information"
+msgid "Write a reply"
+msgstr ""
+
+msgid "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
+msgstr ""
+
+msgid "access to documents"
+msgstr ""
+
+msgid "documents"
 msgstr ""
 
 msgid "follower"
@@ -221,7 +296,7 @@ msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "information"
+msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
 msgstr ""
 
 msgid "type your search term here"
@@ -230,8 +305,17 @@ msgstr ""
 msgid "unknown status "
 msgstr ""
 
+msgid "{{info_request_user_name}} only:"
+msgstr ""
+
+msgid "{{public_body_name}} only:"
+msgstr ""
+
 msgid "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 msgstr ""
 
 msgid "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
+msgstr ""
+
+msgid "{{site_name}} blog and tweets"
 msgstr ""

--- a/locale-theme/de/app.po
+++ b/locale-theme/de/app.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 11:32+0000\n"
-"PO-Revision-Date: 2016-06-10 11:39+0000\n"
+"POT-Creation-Date: 2016-09-26 03:15-0700\n"
+"PO-Revision-Date: 2016-09-26 10:18+0000\n"
 "Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: German (http://www.transifex.com/mysociety/asktheeu-theme/language/de/)\n"
 "Language: de\n"
@@ -19,6 +19,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+msgstr ""
+
+msgid "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+msgstr ""
+
+msgid "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
+msgstr ""
 
 msgid "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
 msgstr "Ein Projekt von <a href=\\\"http://www.access-info.org\\\">Access Info Europe</a>, ermöglicht durch <a href=\\\"http://alaveteli.org\\\">Alaveteli</a>"
@@ -33,6 +42,9 @@ msgid "Access Info"
 msgstr ""
 
 msgid "An access to documents request"
+msgstr ""
+
+msgid "Anyone:"
 msgstr ""
 
 msgid "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
@@ -59,8 +71,14 @@ msgstr "Anfragen ansehen"
 msgid "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 msgstr "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spanien)"
 
+msgid "Confirmatory application for {{email_subject}}"
+msgstr ""
+
 msgid "Contact"
 msgstr "Kontakt"
+
+msgid "Download a zip file of all correspondence"
+msgstr ""
 
 msgid "Error message"
 msgstr ""
@@ -77,6 +95,9 @@ msgstr "Erhalte Antworten von EU-Institutionen"
 msgid "Gone Postal"
 msgstr ""
 
+msgid "Great news!"
+msgstr ""
+
 msgid "Homepage header photo © European Union 2014 - European Parliament"
 msgstr ""
 
@@ -89,6 +110,12 @@ msgstr "Wie benutze ich AsktheEU.org?"
 msgid "If you believe this request is not suitable, you can report it for attention by the site administrators"
 msgstr ""
 
+msgid "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+msgstr ""
+
+msgid "If you write about this request (for example in a forum or a blog) please link to this page."
+msgstr ""
+
 msgid "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 msgstr "Falls {{email_address}} die falsche Email-Adresse für Anfragen auf Dokumentenzugangs an {{public_body_name}} ist, teilen Sie dies dem {{site_name}} team bitte durch eine Email an team@asktheEU.org mit."
 
@@ -97,6 +124,9 @@ msgstr ""
 
 msgid "Latest news and campaigns"
 msgstr "Neuigkeiten und Kampagnen"
+
+msgid "Let other people know what you’ve found out"
+msgstr ""
 
 msgid "Make a request"
 msgstr "Anfrage stellen"
@@ -146,10 +176,16 @@ msgstr ""
 msgid "Report this request"
 msgstr ""
 
+msgid "Request an internal review (also called a confirmatory application)"
+msgstr ""
+
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr ""
 
 msgid "Requires Admin"
+msgstr ""
+
+msgid "Respond to request"
 msgstr ""
 
 msgid "SUPPORT THE CAMPAIGNS"
@@ -161,16 +197,28 @@ msgstr ""
 msgid "See all"
 msgstr "Alle ansehen"
 
+msgid "Send a followup"
+msgstr ""
+
 msgid "Send a request"
 msgstr "Anfrage stellen"
 
+msgid "Share on Facebook"
+msgstr ""
+
 msgid "Similar requests"
+msgstr ""
+
+msgid "Submit Search"
 msgstr ""
 
 msgid "Successful"
 msgstr ""
 
 msgid "Successful requests"
+msgstr ""
+
+msgid "Things to do with this request"
 msgstr ""
 
 msgid "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
@@ -197,6 +245,9 @@ msgstr "Top-Anfragen"
 msgid "Transferred."
 msgstr ""
 
+msgid "Tweet it"
+msgstr ""
+
 msgid "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 msgstr ""
 
@@ -207,6 +258,9 @@ msgid "Unknown Status"
 msgstr ""
 
 msgid "Unsuitable?"
+msgstr ""
+
+msgid "Update the status of this request"
 msgstr ""
 
 msgid "User Withdrawn"
@@ -221,11 +275,17 @@ msgstr ""
 msgid "Waiting Response"
 msgstr ""
 
-msgid "What information has been released?"
+msgid "We're glad you got all the information that you wanted."
 msgstr ""
 
 msgid "Which EU body?"
 msgstr "Wen anfragen?"
+
+msgid "Write a reply"
+msgstr ""
+
+msgid "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
+msgstr ""
 
 msgid "access to documents"
 msgstr ""
@@ -238,14 +298,26 @@ msgid_plural "followers"
 msgstr[0] ""
 msgstr[1] ""
 
+msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
+msgstr ""
+
 msgid "type your search term here"
 msgstr ""
 
 msgid "unknown status "
 msgstr ""
 
+msgid "{{info_request_user_name}} only:"
+msgstr ""
+
+msgid "{{public_body_name}} only:"
+msgstr ""
+
 msgid "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 msgstr ""
 
 msgid "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
+msgstr ""
+
+msgid "{{site_name}} blog and tweets"
 msgstr ""

--- a/locale-theme/en/app.po
+++ b/locale-theme/en/app.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 11:32+0000\n"
-"PO-Revision-Date: 2016-06-10 11:39+0000\n"
+"POT-Creation-Date: 2016-09-26 03:15-0700\n"
+"PO-Revision-Date: 2016-09-26 10:18+0000\n"
 "Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: English (http://www.transifex.com/mysociety/asktheeu-theme/language/en/)\n"
 "Language: en\n"
@@ -16,6 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+msgstr "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+
+msgid "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+msgstr "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+
+msgid "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
+msgstr "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
 
 msgid "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
 msgstr "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
@@ -31,6 +40,9 @@ msgstr "Access Info"
 
 msgid "An access to documents request"
 msgstr "An access to documents request"
+
+msgid "Anyone:"
+msgstr "Anyone:"
 
 msgid "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
 msgstr "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
@@ -56,8 +68,14 @@ msgstr "Browse requests"
 msgid "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 msgstr "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 
+msgid "Confirmatory application for {{email_subject}}"
+msgstr "Confirmatory application for {{email_subject}}"
+
 msgid "Contact"
 msgstr "Contact"
+
+msgid "Download a zip file of all correspondence"
+msgstr "Download a zip file of all correspondence"
 
 msgid "Error message"
 msgstr "Error message"
@@ -74,6 +92,9 @@ msgstr "Get answers from EU Institutions"
 msgid "Gone Postal"
 msgstr "Gone Postal"
 
+msgid "Great news!"
+msgstr "Great news!"
+
 msgid "Homepage header photo © European Union 2014 - European Parliament"
 msgstr "Homepage header photo © European Union 2014 - European Parliament"
 
@@ -86,6 +107,12 @@ msgstr "How to AskTheEU.org"
 msgid "If you believe this request is not suitable, you can report it for attention by the site administrators"
 msgstr "If you believe this request is not suitable, you can report it for attention by the site administrators"
 
+msgid "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+msgstr "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+
+msgid "If you write about this request (for example in a forum or a blog) please link to this page."
+msgstr "If you write about this request (for example in a forum or a blog) please link to this page."
+
 msgid "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 msgstr "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 
@@ -94,6 +121,9 @@ msgstr "Internal Review"
 
 msgid "Latest news and campaigns"
 msgstr "Latest news and campaigns"
+
+msgid "Let other people know what you’ve found out"
+msgstr "Let other people know what you’ve found out"
 
 msgid "Make a request"
 msgstr "Make a request"
@@ -143,11 +173,17 @@ msgstr "Rejected"
 msgid "Report this request"
 msgstr "Report this request"
 
+msgid "Request an internal review (also called a confirmatory application)"
+msgstr "Request an internal review (also called a confirmatory application)"
+
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 
 msgid "Requires Admin"
 msgstr "Requires Admin"
+
+msgid "Respond to request"
+msgstr "Respond to request"
 
 msgid "SUPPORT THE CAMPAIGNS"
 msgstr "SUPPORT THE CAMPAIGNS"
@@ -158,17 +194,29 @@ msgstr "Search"
 msgid "See all"
 msgstr "See all"
 
+msgid "Send a followup"
+msgstr "Send a followup"
+
 msgid "Send a request"
 msgstr "Send a request"
 
+msgid "Share on Facebook"
+msgstr "Share on Facebook"
+
 msgid "Similar requests"
 msgstr "Similar requests"
+
+msgid "Submit Search"
+msgstr "Submit Search"
 
 msgid "Successful"
 msgstr "Successful"
 
 msgid "Successful requests"
 msgstr "Successful requests"
+
+msgid "Things to do with this request"
+msgstr "Things to do with this request"
 
 msgid "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
 msgstr "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
@@ -194,6 +242,9 @@ msgstr "Top requests"
 msgid "Transferred."
 msgstr "Transferred."
 
+msgid "Tweet it"
+msgstr "Tweet it"
+
 msgid "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 msgstr "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 
@@ -205,6 +256,9 @@ msgstr "Unknown Status"
 
 msgid "Unsuitable?"
 msgstr "Unsuitable?"
+
+msgid "Update the status of this request"
+msgstr "Update the status of this request"
 
 msgid "User Withdrawn"
 msgstr "User Withdrawn"
@@ -218,11 +272,17 @@ msgstr "Waiting Clarification"
 msgid "Waiting Response"
 msgstr "Waiting Response"
 
-msgid "What information has been released?"
-msgstr "What information has been released?"
+msgid "We're glad you got all the information that you wanted."
+msgstr "We're glad you got all the information that you wanted."
 
 msgid "Which EU body?"
 msgstr "Which EU body?"
+
+msgid "Write a reply"
+msgstr "Write a reply"
+
+msgid "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
+msgstr "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
 
 msgid "access to documents"
 msgstr "access to documents"
@@ -235,14 +295,26 @@ msgid_plural "followers"
 msgstr[0] "follower"
 msgstr[1] "followers"
 
+msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
+msgstr "mySociety:Helping people set up sites like {{site_name}} all over the world"
+
 msgid "type your search term here"
 msgstr "type your search term here"
 
 msgid "unknown status "
 msgstr "unknown status "
 
+msgid "{{info_request_user_name}} only:"
+msgstr "{{info_request_user_name}} only:"
+
+msgid "{{public_body_name}} only:"
+msgstr "{{public_body_name}} only:"
+
 msgid "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 msgstr "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 
 msgid "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
 msgstr "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
+
+msgid "{{site_name}} blog and tweets"
+msgstr "{{site_name}} blog and tweets"

--- a/locale-theme/es/app.po
+++ b/locale-theme/es/app.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 11:32+0000\n"
-"PO-Revision-Date: 2016-06-10 11:39+0000\n"
+"POT-Creation-Date: 2016-09-26 03:15-0700\n"
+"PO-Revision-Date: 2016-09-26 10:18+0000\n"
 "Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: Spanish (http://www.transifex.com/mysociety/asktheeu-theme/language/es/)\n"
 "Language: es\n"
@@ -19,6 +19,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+msgstr ""
+
+msgid "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+msgstr ""
+
+msgid "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
+msgstr ""
 
 msgid "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
 msgstr "Un project d’<a href=\\\"http://www.access-info.org\\\">Access Info Europe</a> rendu possible par <a href=\\\"http://alaveteli.org\\\">Alaveteli</a>"
@@ -33,6 +42,9 @@ msgid "Access Info"
 msgstr "Access Info"
 
 msgid "An access to documents request"
+msgstr ""
+
+msgid "Anyone:"
 msgstr ""
 
 msgid "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
@@ -59,8 +71,14 @@ msgstr "Ver solicitudes"
 msgid "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 msgstr "Cava de San Miguel 8, 4º centro. 28005 Madrid (España)"
 
+msgid "Confirmatory application for {{email_subject}}"
+msgstr ""
+
 msgid "Contact"
 msgstr "Contacto"
+
+msgid "Download a zip file of all correspondence"
+msgstr ""
 
 msgid "Error message"
 msgstr "Mensaje de error"
@@ -77,6 +95,9 @@ msgstr "Consigue respuestas de las instituciones de la Unión Europea"
 msgid "Gone Postal"
 msgstr "Tramitada por correo postal"
 
+msgid "Great news!"
+msgstr ""
+
 msgid "Homepage header photo © European Union 2014 - European Parliament"
 msgstr "Foto de portada © Unión Europea 2014 - Parlamento Europeo"
 
@@ -89,6 +110,12 @@ msgstr "Cómo utilizar AsktheEU.org"
 msgid "If you believe this request is not suitable, you can report it for attention by the site administrators"
 msgstr "Si crees que esta solicitud no es apropiada, puedes informar a los administradores web"
 
+msgid "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+msgstr ""
+
+msgid "If you write about this request (for example in a forum or a blog) please link to this page."
+msgstr ""
+
 msgid "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 msgstr "Si {{email_address}} no es la dirección correcta para enviar solicitudes a {{public_body_name}}, por favor informa al equipo de {{site_name}} por team@asktheEU.org"
 
@@ -97,6 +124,9 @@ msgstr "Reclamación Interna"
 
 msgid "Latest news and campaigns"
 msgstr "Últimas noticias y campañas"
+
+msgid "Let other people know what you’ve found out"
+msgstr ""
 
 msgid "Make a request"
 msgstr "Enviar una solicitud"
@@ -146,11 +176,17 @@ msgstr "Rechazada"
 msgid "Report this request"
 msgstr "Alerta acerca de esta solicitud"
 
+msgid "Request an internal review (also called a confirmatory application)"
+msgstr ""
+
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr "No se consideran válidas las solicitudes de información de carácter personal o aquellas que son abusivas (<a href=\"/help/about\">leer más</a>)."
 
 msgid "Requires Admin"
 msgstr "Requiere Administrador"
+
+msgid "Respond to request"
+msgstr ""
 
 msgid "SUPPORT THE CAMPAIGNS"
 msgstr "APOYA LAS CAMPAÑAS"
@@ -161,17 +197,29 @@ msgstr "Buscar"
 msgid "See all"
 msgstr "Ver todas"
 
+msgid "Send a followup"
+msgstr ""
+
 msgid "Send a request"
 msgstr "Enviar una solicitud"
 
+msgid "Share on Facebook"
+msgstr ""
+
 msgid "Similar requests"
 msgstr "Solicitudes relacionadas"
+
+msgid "Submit Search"
+msgstr ""
 
 msgid "Successful"
 msgstr "Exitosa"
 
 msgid "Successful requests"
 msgstr "Solicitudes exitosas"
+
+msgid "Things to do with this request"
+msgstr ""
 
 msgid "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
 msgstr "Esta es una solicitud de acceso a documentos al amparo del Artículo 15 de los tratados de la UE y, donde aplicable, el Reglamento 1049/2001, la cual se ha enviado a través de {{site_name}}."
@@ -197,6 +245,9 @@ msgstr "Solicitudes destacadas"
 msgid "Transferred."
 msgstr "Remitida."
 
+msgid "Tweet it"
+msgstr ""
+
 msgid "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 msgstr "Al amparo del derecho de acceso a documentos contemplado en los tratados de la UE, y desarrollado en el Reglamento 1049/2001, solicito los documentos que contienen la siguiente información:\\n\\n"
 
@@ -208,6 +259,9 @@ msgstr "Estado Desconocido"
 
 msgid "Unsuitable?"
 msgstr "¿Insatisfactoria?"
+
+msgid "Update the status of this request"
+msgstr ""
 
 msgid "User Withdrawn"
 msgstr "Retirada por Usuario"
@@ -221,11 +275,17 @@ msgstr "Esperando Aclaración"
 msgid "Waiting Response"
 msgstr "Esperando Respuesta"
 
-msgid "What information has been released?"
+msgid "We're glad you got all the information that you wanted."
 msgstr ""
 
 msgid "Which EU body?"
 msgstr "¿A quién preguntar?"
+
+msgid "Write a reply"
+msgstr ""
+
+msgid "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
+msgstr ""
 
 msgid "access to documents"
 msgstr ""
@@ -238,14 +298,26 @@ msgid_plural "followers"
 msgstr[0] "seguidor"
 msgstr[1] "seguidores"
 
+msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
+msgstr ""
+
 msgid "type your search term here"
 msgstr "introduce los términos de búsqueda"
 
 msgid "unknown status "
 msgstr "estado desconocido"
 
+msgid "{{info_request_user_name}} only:"
+msgstr ""
+
+msgid "{{public_body_name}} only:"
+msgstr ""
+
 msgid "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 msgstr "{{public_body_url}} ha contestado y dice que <strong>ha remitido tu solicitud a otro organismo</strong>."
 
 msgid "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
 msgstr "{{public_body_url}} ha contestado y dice que <strong>tienes que remitir tu solicitud a otra institución</strong>."
+
+msgid "{{site_name}} blog and tweets"
+msgstr ""

--- a/locale-theme/fr/app.po
+++ b/locale-theme/fr/app.po
@@ -11,8 +11,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: alaveteli\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-06-10 11:32+0000\n"
-"PO-Revision-Date: 2016-06-10 11:39+0000\n"
+"POT-Creation-Date: 2016-09-26 03:15-0700\n"
+"PO-Revision-Date: 2016-09-26 10:18+0000\n"
 "Last-Translator: Liz Conlan <liz@mysociety.org>\n"
 "Language-Team: French (http://www.transifex.com/mysociety/asktheeu-theme/language/fr/)\n"
 "Language: fr\n"
@@ -20,6 +20,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "<a href=\"{{url}}\">Add an annotation</a> (to help the requester or others)"
+msgstr ""
+
+msgid "<p>All done! Thank you very much for your help.</p><p>There are <a href=\"{{helpus_url}}\">more things you can do</a> to help {{site_name}}.</p>"
+msgstr ""
+
+msgid "A full history of my request and all correspondence is available on the Internet at this address: {{url}}"
+msgstr ""
 
 msgid "A project by <a href=\"http://www.access-info.org\">Access Info Europe</a>, powered by <a href=\"http://alaveteli.org\">Alaveteli</a>"
 msgstr "Un project d’<a href=\\\"http://www.access-info.org\\\">Access Info Europe</a> rendu possible par <a href=\\\"http://alaveteli.org\\\">Alaveteli</a>"
@@ -34,6 +43,9 @@ msgid "Access Info"
 msgstr "Access Info"
 
 msgid "An access to documents request"
+msgstr ""
+
+msgid "Anyone:"
 msgstr ""
 
 msgid "AskTheEU.org is an online platform for citizens to send access to documents requests directly to EU institutions."
@@ -60,8 +72,14 @@ msgstr "Voir les demandes"
 msgid "Cava de San Miguel 8, 4º centro. 28005 Madrid (Spain)"
 msgstr "Cava de San Miguel 8, 4º centro. 28005 Madrid (Espagne)"
 
+msgid "Confirmatory application for {{email_subject}}"
+msgstr ""
+
 msgid "Contact"
 msgstr "Contacte"
+
+msgid "Download a zip file of all correspondence"
+msgstr ""
 
 msgid "Error message"
 msgstr "Message d'erreur"
@@ -78,6 +96,9 @@ msgstr "Obtenez des réponses des institutions de l'Union européenne"
 msgid "Gone Postal"
 msgstr "Envoyé par la poste"
 
+msgid "Great news!"
+msgstr ""
+
 msgid "Homepage header photo © European Union 2014 - European Parliament"
 msgstr "Photo sur la page d'accueil © Union Européenne 2014 - Parlement Européen"
 
@@ -90,6 +111,12 @@ msgstr "Comment utiliser AsktheEU.org"
 msgid "If you believe this request is not suitable, you can report it for attention by the site administrators"
 msgstr "Si vous trouvez que cette demande n'est pas apropriée, vous pouvez la signaler aux administrateurs du site web."
 
+msgid "If you write about this request (for example in a forum or a blog) please link to this page, and <a href=\"{{url}}\">add an annotation</a> below telling people about your writing."
+msgstr ""
+
+msgid "If you write about this request (for example in a forum or a blog) please link to this page."
+msgstr ""
+
 msgid "If {{email_address}} is the wrong address for information requests to {{public_body_name}}, please tell the {{site_name}} team on email team@asktheEU.org"
 msgstr "Si {{email_address}} n'est pas la bonne adresse pour demander de l'information à {{public_body_name}}, veulliez prevenir l'équipe {{site_name}} par mail team@asktheEU.org"
 
@@ -98,6 +125,9 @@ msgstr "Examen interne"
 
 msgid "Latest news and campaigns"
 msgstr "Les nouvelles et campagnes"
+
+msgid "Let other people know what you’ve found out"
+msgstr ""
 
 msgid "Make a request"
 msgstr "Faire une demande"
@@ -147,11 +177,17 @@ msgstr "Demande rejetée"
 msgid "Report this request"
 msgstr "Signaler cette demande"
 
+msgid "Request an internal review (also called a confirmatory application)"
+msgstr ""
+
 msgid "Requests for personal information and vexatious requests are not considered valid for FOI purposes (<a href=\"/help/about\">read more</a>)."
 msgstr "Les demandes d'information personelle ainsi que les demandes vexantes ne sont pas valables en accordance avec les fins de la liberté d'information (<a href=\"/help/about\">savoir plus</a>)."
 
 msgid "Requires Admin"
 msgstr "Admin requis"
+
+msgid "Respond to request"
+msgstr ""
 
 msgid "SUPPORT THE CAMPAIGNS"
 msgstr "SOUTENEZ LES CAMPAGNES"
@@ -162,17 +198,29 @@ msgstr "Rechercher"
 msgid "See all"
 msgstr "Tout voir"
 
+msgid "Send a followup"
+msgstr ""
+
 msgid "Send a request"
 msgstr "Faire une demande"
 
+msgid "Share on Facebook"
+msgstr ""
+
 msgid "Similar requests"
 msgstr "Des demandes similares"
+
+msgid "Submit Search"
+msgstr ""
 
 msgid "Successful"
 msgstr "Demande réussite"
 
 msgid "Successful requests"
 msgstr "Demandes réussites"
+
+msgid "Things to do with this request"
+msgstr ""
 
 msgid "This is a request for access to information under Article 15 of the TFEU and, where applicable, Regulation 1049/2001 which has been sent via the {{site_name}} website."
 msgstr "Celle ci est une demande d'accès à l'information au titre de l'article 15 du TFUE et là où il soit applicable le Règlement 1049/2001, envoyée par le site web {{site_name}}."
@@ -198,6 +246,9 @@ msgstr "Le top des demandes"
 msgid "Transferred."
 msgstr "Demande transférée."
 
+msgid "Tweet it"
+msgstr ""
+
 msgid "Under the right of access to documents in the EU treaties, as developed in Regulation 1049/2001, I am requesting documents which contain the following information:\\n\\n"
 msgstr "Au titre du droit d'accès aux documents dans les traités de l'UE, élaboré dans le Règlement 1049/2001, je demande les documents contenant ces informations:\\n\\n"
 
@@ -209,6 +260,9 @@ msgstr "Statut inconnu"
 
 msgid "Unsuitable?"
 msgstr "Inapproprié ?"
+
+msgid "Update the status of this request"
+msgstr ""
 
 msgid "User Withdrawn"
 msgstr "Utilisateur retiré"
@@ -222,11 +276,17 @@ msgstr "En attendant une clarification"
 msgid "Waiting Response"
 msgstr "En attendant une reponse"
 
-msgid "What information has been released?"
+msgid "We're glad you got all the information that you wanted."
 msgstr ""
 
 msgid "Which EU body?"
 msgstr "À quelle institution?"
+
+msgid "Write a reply"
+msgstr ""
+
+msgid "\\n\\nPlease pass this on to the person who reviews confirmatory applications.\\n\\nI am filing the following confirmatory application with regards to my access to documents request '{{info_request_title}}'."
+msgstr ""
 
 msgid "access to documents"
 msgstr "Accès à l'information"
@@ -239,14 +299,26 @@ msgid_plural "followers"
 msgstr[0] "Supporter"
 msgstr[1] "Supporters"
 
+msgid "mySociety:Helping people set up sites like {{site_name}} all over the world"
+msgstr ""
+
 msgid "type your search term here"
 msgstr "Tapez le mot recherché"
 
 msgid "unknown status "
 msgstr "Statut inconnu"
 
+msgid "{{info_request_user_name}} only:"
+msgstr ""
+
+msgid "{{public_body_name}} only:"
+msgstr ""
+
 msgid "{{public_body_url}} has replied saying <strong>they have transferred your request to another public body</strong>."
 msgstr "{{public_body_url}} a répondu en disant que <strong>votre demande a eté transférée à une autre institution publique</strong>."
 
 msgid "{{public_body_url}} has replied saying <strong>you have to contact another public body</strong>."
 msgstr "{{public_body_url}} a répondu en disant que  <strong>vous devez contacter une autre institution publique </strong>."
+
+msgid "{{site_name}} blog and tweets"
+msgstr ""


### PR DESCRIPTION
First pass attempt, checking whether this is a useful approach. Trying to override as little in the templates as possible.
- updates the outgoing message subject line so that the authority receives an email about a "confirmatory application" (intended to be a translatable string)
- changes the default text used when creating an internal review message (wording borrowed from http://blogs.bmj.com/bmj/files/2014/09/jim-Appeal-against-refusal.pdf and should be considered holding copy without input from Andreas)
- overrides the `request/_after_actions.html.erb` to explain that an internal review is a confirmatory application

Tested against Alaveteli 0.24.1.9 as the theme has not been updated to work with 0.25

Closes #31