### PR TITLE
[#68] Only disable the authority list if no tag (or "all") was requested

### DIFF
--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -6,9 +6,6 @@ Rails.application.routes.draw do
   match '/help/help_out' => 'help#help_out', :as => 'help_help_out'
   match '/help/right_to_know' => 'help#right_to_know', :as => 'help_right_to_know'
 
-  # We want to start by showing the public bodies categories and search only
-  match '/body/' => 'public_body#index', :as => "body_index"
-
   # redirect the blog page to blog.asktheeu.org
   match '/blog/' => redirect('http://blog.asktheeu.org/')
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -84,16 +84,6 @@ Rails.configuration.to_prepare do
     end
   end
 
-  PublicBodyController.class_eval do
-    def index
-      # Retrieve no bodies, but return them through a pagination object,
-      # so the view code works the same
-      @public_bodies = PublicBody.where(false).paginate(:page => 10)
-      @description = ''
-      render :template => "public_body/list"
-    end
-  end
-
   HelpController.class_eval do
     def help_out
       render :template => "help/help_out"


### PR DESCRIPTION
Fixes #68 

(blocking "all" might be an overreach but I think it's inline with the original intention not to show an unfiltered list - at least that's my interpretation of that intention)