### PR TITLE
Update Time instances to local time zone

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -52,7 +52,7 @@ Rails.configuration.to_prepare do
       # if the fragment is unreadable or has reached expiry
       # attempt to pull in the blog feed
       if updated.nil? || !fragment_exist?(@fragment_key) ||
-         Time.now > (Time.parse(updated) + expires)
+         Time.zone.now > (Time.zone.parse(updated) + expires)
         # keep a note of the old key
         old_key = @fragment_key.dup
 
@@ -79,7 +79,7 @@ Rails.configuration.to_prepare do
       end
     end
 
-    def create_timestamp(time=Time.now)
+    def create_timestamp(time=Time.zone.now)
       time.strftime('%Y%m%d-%H:%M:%S')
     end
   end
@@ -96,7 +96,7 @@ Rails.configuration.to_prepare do
 
   RequestGameController.class_eval do
     def play
-      session[:request_game] = Time.now
+      session[:request_game] = Time.zone.now
 
       @missing = InfoRequest.
         where_old_unclassified.
@@ -118,7 +118,7 @@ Rails.configuration.to_prepare do
                            :site_name => site_name)
       end
 
-      @league_table_28_days = RequestClassification.league_table(10, [ "created_at >= ?", Time.now - 28.days ])
+      @league_table_28_days = RequestClassification.league_table(10, [ "created_at >= ?", Time.zone.now - 28.days ])
       @league_table_all_time = RequestClassification.league_table(10)
       @play_urls = true
     end

--- a/lib/customstates.rb
+++ b/lib/customstates.rb
@@ -10,9 +10,9 @@ module InfoRequestCustomStates
     waiting_response = self.described_state == "waiting_response" || self.described_state == "deadline_extended"
     return self.described_state unless waiting_response
     return 'waiting_response_very_overdue' if
-      Time.now.strftime("%Y-%m-%d") > self.date_very_overdue_after.strftime("%Y-%m-%d")
+      Time.zone.now.strftime("%Y-%m-%d") > self.date_very_overdue_after.strftime("%Y-%m-%d")
     return 'waiting_response_overdue' if
-      Time.now.strftime("%Y-%m-%d") > self.date_response_required_by.strftime("%Y-%m-%d")
+      Time.zone.now.strftime("%Y-%m-%d") > self.date_response_required_by.strftime("%Y-%m-%d")
     return 'waiting_response'
   end
 

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -23,9 +23,9 @@ describe GeneralController, "when patched by the asktheeu-theme" do
       end
 
       it "can be read back correctly" do
-        time = Time.parse("2016-08-01 09:29:16")
+        time = Time.zone.parse("2016-08-01 09:29:16")
         timestamp = controller.send(:create_timestamp, time)
-        expect(Time.parse(timestamp)).to eq(time)
+        expect(Time.zone.parse(timestamp)).to eq(time)
       end
 
     end
@@ -112,7 +112,7 @@ describe GeneralController, "when patched by the asktheeu-theme" do
     end
 
     context "there is cached content" do
-      let(:updated) { "#{Time.now - 3.minutes}"}
+      let(:updated) { "#{Time.zone.now - 3.minutes}"}
 
       before do
         allow(AlaveteliConfiguration).to receive(:cache_fragments).


### PR DESCRIPTION
Following instruction in the 0.27 upgrade notes.

Note: This will need to be cherry picked onto the release branches 0.28 to 0.33