### PR TITLE
Update variable name in template as info_request is no longer passed in

### DIFF
--- a/lib/views/request/describe_notices/_successful.html.erb
+++ b/lib/views/request/describe_notices/_successful.html.erb
@@ -1,3 +1,5 @@
+<% info_request = InfoRequest.find(info_request_id) %>
+
 <h1><%= _('Great news!') %></h1>
 
 <p class="subtitle">


### PR DESCRIPTION
Fixes error:

undefined local variable or method `info_request' for #<#\<Class\>

(Caused by [this change in core](https://github.com/mysociety/alaveteli/commit/6a2c78a5cc26da87e9f14f072bb4d56a5a65467b) which no longer passes an `info_request` value to `locals`)

Tested in browser locally