### PR TITLE
Refactor blog caching

### DIFF
--- a/lib/views/general/frontpage.html.erb
+++ b/lib/views/general/frontpage.html.erb
@@ -22,7 +22,7 @@
 
 <% end %>
 
-<% cache_if_caching_fragments(@fragment_key) do %>
+<% cache_if_caching_fragments("latest_blog_posts-#{@locale}", :expires_in => 5.minutes) do %>
   <div class="frontpage__tertiary">
 
     <div class="wrapper">

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -69,6 +69,13 @@ describe GeneralController, 'blog caching' do
       controller.send(:blog_cache, 'cache_key', 1.minute)
     end
 
+    it 'assigns fragment to blog cache instance variable' do
+      controller.send(:blog_cache, 'cache_key', 1.minute)
+      expect(controller.instance_variable_get(:@blog_items)).to(
+        eq ['blog_item']
+      )
+    end
+
   end
 
   context 'cache full' do


### PR DESCRIPTION
Use Rails' expires_in option so we don't have to keep track when the
blog feed was last updated.