### PR TITLE
Fix blog cache

### DIFF
--- a/lib/views/general/frontpage.html.erb
+++ b/lib/views/general/frontpage.html.erb
@@ -22,7 +22,7 @@
 
 <% end %>
 
-<% cache_if_caching_fragments(@fragment_key) do %>
+<% cache_if_caching_fragments(@fragment_key, skip_digest: true) do %>
   <div class="frontpage__tertiary">
 
     <div class="wrapper">


### PR DESCRIPTION
Rails have started adding cache digests to the fragment cache keys this
means the custom code in our controller isn't able to find the current
fragment and believes the blog is uncached, resulting in the blog feed
being hit every time the frontpage in reloaded.

Paired with @garethrees on this.