### PR TITLE
Add pro help page

### DIFF
--- a/lib/views/help/_sidebar.de.html.erb
+++ b/lib/views/help/_sidebar.de.html.erb
@@ -38,6 +38,10 @@
 
   <h3><%= link_to_unless_current "Impressum", help_credits_path %></h3>
 
+  <% if feature_enabled?(:alaveteli_pro) %>
+    <h2><%= link_to_unless_current "Pro", help_pro_path %></h2>
+  <% end %>
+
   <h2 id="contact">Kontakt</h2>
   <p>Sollten Sie hier keine Antwort auf Ihre Frage finden oder sollten Sie uns etwas mitteilen wollen, <%= link_to 'nehmen Sie Kontakt auf', help_contact_path %>.
   </p>

--- a/lib/views/help/_sidebar.es.html.erb
+++ b/lib/views/help/_sidebar.es.html.erb
@@ -38,6 +38,10 @@
 
   <h3><%= link_to_unless_current "Agradecimientos", help_credits_path %></h3>
 
+  <% if feature_enabled?(:alaveteli_pro) %>
+    <h2><%= link_to_unless_current "Pro", help_pro_path %></h2>
+  <% end %>
+
   <h2 id="contact">Contáctanos</h2>
   <p>Si tu pregunta no está resuelta aquí, o quieres hacernos llegar algún comentario
   sobre la web, <%= link_to 'contáctanos', help_contact_path %>.

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -30,6 +30,10 @@
 
   <h2><%= link_to_unless_current "Credits", help_credits_path %></h2>
 
+  <% if feature_enabled?(:alaveteli_pro) %>
+    <h2><%= link_to_unless_current "Pro", help_pro_path %></h2>
+  <% end %>
+
   <h2 id="contact">Contact us</h2>
   <p>If your question isn't answered here, or you just wanted to let us know
   something about the site, <%= link_to 'contact us', help_contact_path %>.

--- a/lib/views/help/pro.html.erb
+++ b/lib/views/help/pro.html.erb
@@ -1,0 +1,195 @@
+<% @title = 'Pro' %>
+
+<%= render partial: 'sidebar' %>
+
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="pro">
+    <%= @title %>
+  </h1>
+
+  <ul>
+    <li><%= link_to 'Private requests', '#private-requests' %></li>
+    <li><%= link_to 'Batch', '#batch' %></li>
+  </ul>
+
+  <h2 id="private-requests">
+    Private requests
+   <a href="#private-requests">#</a>
+  </h2>
+
+  <p>
+    Pro users can set a privacy period on a request to delay publication while
+    you work on your story or investigation.
+  </p>
+
+  <p>
+    When a request is private we guarantee that it will only be visible on
+    <%= AlaveteliConfiguration.site_name %> for the period you select.
+    <%= AlaveteliConfiguration.pro_site_name %> administrators will also be able
+    to view your request, but will only do so in the event that they need to fix
+    a problem with it (e.g. failed delivery to the authority). They will not
+    reveal the contents of your request or any response you get to anyone else.
+    The authority may still publish it in a disclosure log as usual.
+  </p>
+
+  <h3 id="how-long-can-i-keep-requests-private">
+    How long can I keep requests private?
+   <a href="#how-long-can-i-keep-requests-private">#</a>
+  </h3>
+
+  <p>
+    Privacy periods can be set for 3, 6 and 12 month periods.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-embargo.jpg',
+                  alt: 'Adding a privacy period' %>
+  </p>
+
+  <p>
+    You will be automatically notified a week before the privacy period expires,
+    and on the date of expiry.
+  </p>
+
+  <p>
+    Once the privacy period ends, your request and following correspondence,
+    including <strong>your name</strong>, will be <strong>
+    <%= link_to 'displayed publicly',
+      help_privacy_path(anchor: 'public_request') %></strong> on this website.
+  </p>
+
+  <h3 id="i-need-more-time-can-i-extend-a-privacy-period">
+    I need more time. Can I extend a privacy period?
+   <a href="#i-need-more-time-can-i-extend-a-privacy-period">#</a>
+  </h3>
+
+  <p>
+    Privacy periods can be extended, but only in the week before the expiry
+    date.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-embargo-extension.jpg',
+                  alt: 'Extending a privacy period' %>
+  </p>
+
+  <p>
+    There is no limit to the number of times a privacy period may be extended,
+    but each extension requires manual confirmation.
+  </p>
+
+  <h3 id="how-do-i-publish-a-request">
+    How do I publish a request?
+   <a href="#how-do-i-publish-a-request">#</a>
+  </h3>
+
+  <p>
+    Requests can be published at any time.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-embargo-publish.jpg',
+                  alt: 'Publish a request' %>
+  </p>
+
+  <h3 id="can-i-make-private-batch-requests">
+    Can I make private batch requests?
+   <a href="#can-i-make-private-batch-requests">#</a>
+  </h3>
+
+  <p>
+    Privacy periods can also be set on batch requests, and their operation
+    follows the same principles as individual requests. Changes to a privacy
+    period on one request belonging to a batch are mirrored to all requests in
+    the batch.
+  </p>
+
+  <h2 id="batch">
+    Batch
+   <a href="#batch">#</a>
+  </h2>
+
+  <p>
+    Batch makes it easy to send and manage requests to multiple authorities.
+  </p>
+
+  <h3 id="how-do-i-make-a-batch-request">
+    How do I make a batch request?
+   <a href="#how-do-i-make-a-batch-request">#</a>
+  </h3>
+
+  <p>
+    Batch allows you to select a list of authorities and write a template
+    request. The request gets sent individually to each authority like a mail
+    merge.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-batch-selection.jpg',
+                  alt: 'Select authorities for a batch' %>
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-batch-write.jpg',
+                  alt: 'Write a batch template' %>
+  </p>
+
+  <h3 id="how-do-i-manage-a-batch-request">
+    How do I manage a batch request?
+   <a href="#how-do-i-manage-a-batch-request">#</a>
+  </h3>
+
+  <p>
+    Progress of a batch can be managed with a convenient progress meter to see
+    how close you are to getting responses from all authorities and making it
+    easy to choose which action to take next.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-batch-list.jpg',
+                  alt: 'Managing batch requests' %>
+  </p>
+
+  <h3 id="how-do-i-manage-batch-privacy-periods">
+    How do I manage batch privacy periods?
+   <a href="#how-do-i-manage-batch-privacy-periods">#</a>
+  </h3>
+
+  <p>
+    Batches can be made private, and privacy periods easily managed across the
+    batch.
+  </p>
+
+  <p>
+    <%= image_tag 'alaveteli-pro/screenshot-batch-privacy.jpg',
+                  alt: 'Manage batch privacy' %>
+  </p>
+
+  <h3 id="how-many-authorities-can-i-add-to-a-batch">
+    How many authorities can I add to a batch?
+   <a href="#how-many-authorities-can-i-add-to-a-batch">#</a>
+  </h3>
+
+  <p>
+    The maximum number of authorities that can be added to a batch is
+    <%= AlaveteliConfiguration.pro_batch_authority_limit %>.
+  </p>
+
+  <h3 id="how-many-batch-requests-can-i-make">
+    How many batch requests can I make?
+   <a href="#how-many-batch-requests-can-i-make">#</a>
+  </h3>
+
+  <p>
+    We recommend sending a pilot batch to a sample of authorities to test the
+    request. Once you know the authorities hold the type of data that you’re
+    asking for you can then request from the remaining authorities.
+  </p>
+
+  <p>
+    There’s no limit to the number of batches that can be sent, but Pro users
+    are required to abide by our guidelines about writing
+    <%= link_to 'responsible requests',
+      help_requesting_path(anchor: 'responsible') %>.
+  </p>
+</div>

--- a/lib/views/help/requesting.de.html.erb
+++ b/lib/views/help/requesting.de.html.erb
@@ -64,7 +64,7 @@
 
   <h1 id="tips">Hilfreiche Anfragen-Tipps</h1>
 
-  <h2 id="focused">7. Was macht eine gute Anfrage aus?</h2>
+  <h2 id="focused"><a name="responsible"></a>7. Was macht eine gute Anfrage aus?</h2>
   <p>Bitte fügen Sie Ihrer Anfrage ausschließlich Informationen bei, welche es dem Empfänger vereinfachen die Dokumente mit den von Ihnen gewünschten Informationen zu identifizieren.</p>
   <p>Kurzum, knappe und bündige Nachrichten erleichtern es dem entsprechenden EU Beamten die von Ihnen gewünschten Informationen zu identifizieren und somit werden Sie Ihre Antwort auch schneller erhalten.</p>
   <p>Eine gut formulierte Anfrage macht es auch unwahrscheinlicher, dass ein Beamter Ihre Anfrage aufgrund von unklarer Formulierung oder dergleichen ablehnen kann. Aber machen Sie sich keine zu großen Sorgen, Ihre Anfrage muss nicht perfekt sein, Ihr EU-Kontakt sollte sich im Falle eventuellem Klärungsbedarfs an Sie wenden.</p>

--- a/lib/views/help/requesting.es.html.erb
+++ b/lib/views/help/requesting.es.html.erb
@@ -62,7 +62,7 @@
 
   <h1 id="tips">Consejos sobre las solicitudes</h1>
 
-  <h2 id="focused">7. ¿Qué constituye una buena solicitud?</h2>
+  <h2 id="focused"><a name="responsible"></a>7. ¿Qué constituye una buena solicitud?</h2>
   <p>Por favor, incluye en tu solicitud lo necesario para identificar fácilmente la información que estás pidiendo de la institución.</p>
   <p>Los mensajes cortos y concisos hacen que sea más fácil para los funcionarios de la UE identificar la información que pides, lo que significa que recibirás una respuesta más rápidamente.</p>
   <p>Además, una petición bien formulada da menos razones a los funcionarios para rechazar tu solicitud por considerarla vaga o poco clara. Sin embargo, no te preocupes por hacerla perfecta: el órgano de la UE se pondrá en contacto contigo para aclarar lo que no hayan entendido de tu petición.</p>

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -58,7 +58,7 @@
      <li>Please <a href="<%= help_contact_url %>">contact us</a> if you think AsktheEU.org is missing an EU institution that comes under EU transparency rules</li>
   </ul>
 
-  <h2 id="focused">What makes a good request?</h2>
+  <h2 id="focused"><a name="responsible"></a>What makes a good request?</h2>
   <p>A good request is succinct and precise – just put in your request only what is needed so that the EU public official can easily identify the documents which contain the information you are asking for. Remember, you need to ask for documents, not only information. <a href="#the_right">What's the difference between documents and information?</a></p>
   <p>A short, well-formulated message also gives public officials fewer reasons to reject your request on the grounds that it is too vague or not clear. But don’t worry about making it perfect: the EU body should come back to you for a clarification if they have not understood.</p>
   <p>You can ask for the same document from more than one body, although it’s best to start with the body most likely to hold the information you need.</p>


### PR DESCRIPTION
Requires mysociety/alaveteli#5292
Connects to mysociety/transparency-adessium#18

Only linked to if pro is enabled. The routing in core also has a
constraint. **Content copied from mysociety/alavetelitheme#110**

## Screenshot

![screencapture-10-10-10-30-3000-help-pro-2019-07-26-18_14_15](https://user-images.githubusercontent.com/27760/61968967-41e40900-afd1-11e9-8d90-a5665f593e70.png)

## Notes to reviewer

Potential things to flag up here:

* ~The last link on the page is to 'responsible requests' (`help_requesting_path(anchor: 'responsible')`) which **does not exist on the AskTheEU help page**~ fixed! (see below)
* There is currently a section in help/requesting about what to do if you want to keep request private - they might like to consider rewording this when Pro is up and running!