### PR TITLE
Style the pro pricing tier

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -1101,3 +1101,12 @@ dt {
     max-width: 224px;
   }
 }
+
+// Pro Plans
+.pricing__tier__heading {
+  background-image: linear-gradient(46deg, #aacc4b 0%, $color_asktheeu_green 9%, $color_asktheeu_blue 63%);
+}
+
+.pricing__tier__content {
+  background-color: $color_sand;
+}


### PR DESCRIPTION
* Make `pricing__tier__heading` better reflect the site theme
* Add background to `pricing__tier__content` as the general page
  background is white

**BEFORE**

![Screenshot 2020-01-30 at 16 22 58](https://user-images.githubusercontent.com/282788/73468526-d4000c00-437c-11ea-8e1c-d3ba079e0bb7.png)


**AFTER**

![Screenshot 2020-01-30 at 16 19 23](https://user-images.githubusercontent.com/282788/73468421-b03cc600-437c-11ea-9ca9-6f4fe9116915.png)
