### PR TITLE
[#72] Update internal review letter override

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -48,21 +48,28 @@ Rails.configuration.to_prepare do
 
     # Override the default template text
     def letter(replacements = {})
-      msg = _("\n\nPlease pass this on to the person who reviews " \
-              "confirmatory applications.\n\n" \
-              "I am filing the following confirmatory application with " \
-              "regards to my access to documents request " \
-              "'{{info_request_title}}'.",
-              replacements)
-      msg += "\n\n\n\n"
-      msg += " [ #{ self.class.details_placeholder } ] "
-      msg += "\n\n\n\n"
-      msg += _("A full history of my request and all correspondence " \
-               "is available on the Internet at this address: {{url}}",
-               replacements)
-      msg
-    end
+      if replacements[:letter]
+        "\n\n#{ replacements[:letter] }"
+      else
+        msg = _("\n\nPlease pass this on to the person who reviews " \
+                "confirmatory applications.\n\n" \
+                "I am filing the following confirmatory application with " \
+                "regards to my access to documents request " \
+                "'{{info_request_title}}'.",
+                replacements)
+        msg += "\n\n\n\n"
+        msg += " [ #{ self.class.details_placeholder } ]"
 
+        unless replacements[:embargo]
+          msg += "\n\n\n\n"
+          msg += _("A full history of my request and all correspondence " \
+                   "is available on the Internet at this address: {{url}}",
+                   replacements)
+        end
+
+        ActiveSupport::SafeBuffer.new("\n\n") << msg
+      end
+    end
   end
 
   OutgoingMessage.class_eval do


### PR DESCRIPTION
Update `OutgoingMessage::Template::InternalReview#letter` override

Needs to account for embargoed requests now that they use Pro.

Fixes #72.