### PR TITLE
Reconcile custom classification form states

### DIFF
--- a/lib/views/general/_custom_state_transitions_complete.html.erb
+++ b/lib/views/general/_custom_state_transitions_complete.html.erb
@@ -1,6 +1,6 @@
 <% id_suffix ||= '' %>
-<div>
-  <%= radio_button "classification", "described_state", "referred", :id => 'referred' + id_suffix %>
-  <label for="referred<%=id_suffix%>"><%= _('Authority has <strong>referred you to another public body</strong> for an answer') %></label>
-</div>
 
+<div>
+  <%= classification_radio_button 'referred', id_suffix: id_suffix %>
+  <%= classification_label('referred', _('Authority has <strong>referred you to another public body</strong> for an answer'), id_suffix: id_suffix) %>
+</div>

--- a/lib/views/general/_custom_state_transitions_complete.html.erb
+++ b/lib/views/general/_custom_state_transitions_complete.html.erb
@@ -1,5 +1,6 @@
+<% id_suffix ||= '' %>
 <div>
-  <%= radio_button "incoming_message", "described_state", "referred", :id => 'referred' + id_suffix %>
+  <%= radio_button "classification", "described_state", "referred", :id => 'referred' + id_suffix %>
   <label for="referred<%=id_suffix%>"><%= _('Authority has <strong>referred you to another public body</strong> for an answer') %></label>
 </div>
 

--- a/lib/views/general/_custom_state_transitions_pending.html.erb
+++ b/lib/views/general/_custom_state_transitions_pending.html.erb
@@ -1,5 +1,6 @@
 <% id_suffix ||= '' %>
+
 <div>
-  <%= radio_button "classification", "described_state", "transferred", :id => 'transferred' + id_suffix %>
-  <label for="transferred<%=id_suffix%>"><%= _('Authority has <strong>transferred your request</strong> to another public body.') %></label>
+  <%= classification_radio_button 'transferred', id_suffix: id_suffix %>
+  <%= classification_label('transferred', _('Authority has <strong>transferred your request</strong> to another public body.'), id_suffix: id_suffix) %>
 </div>

--- a/lib/views/general/_custom_state_transitions_pending.html.erb
+++ b/lib/views/general/_custom_state_transitions_pending.html.erb
@@ -1,4 +1,5 @@
+<% id_suffix ||= '' %>
 <div>
-  <%= radio_button "incoming_message", "described_state", "transferred", :id => 'transferred' + id_suffix %>
+  <%= radio_button "classification", "described_state", "transferred", :id => 'transferred' + id_suffix %>
   <label for="transferred<%=id_suffix%>"><%= _('Authority has <strong>transferred your request</strong> to another public body.') %></label>
 </div>


### PR DESCRIPTION
* Update custom describe state radio button params
* Extract custom state transitions to helpers

Rendering with custom states:

![Screenshot 2020-09-15 at 16 32 22](https://user-images.githubusercontent.com/282788/93232218-8dc3b580-f771-11ea-992d-34cd5a81f2cc.png)

Successfully classified with custom state:

![Screenshot 2020-09-15 at 16 32 42](https://user-images.githubusercontent.com/282788/93232234-93210000-f771-11ea-82f6-f44e59795b68.png)
