### PR TITLE
Add timeout to external PDFtk commands

### DIFF
--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -1,0 +1,26 @@
+require 'alaveteli_text_masker'
+
+module AlaveteliTextMasker
+  private
+
+  def uncompress_pdf(text)
+    AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress", :stdin_string => text, :timeout => 300)
+  end
+
+  def compress_pdf(text)
+    if AlaveteliConfiguration::use_ghostscript_compression
+      command = ["gs",
+                 "-sDEVICE=pdfwrite",
+                 "-dCompatibilityLevel=1.4",
+                 "-dPDFSETTINGS=/screen",
+                 "-dNOPAUSE",
+                 "-dQUIET",
+                 "-dBATCH",
+                 "-sOutputFile=-",
+                 "-"]
+    else
+      command = ["pdftk", "-", "output", "-", "compress"]
+    end
+    AlaveteliExternalCommand.run(*(command + [ :stdin_string => text, :timeout => 300 ]))
+  end
+end

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -27,7 +27,8 @@ end
 # Monkey patch app code
 for patch in ['controller_patches.rb',
               'model_patches.rb',
-              'patch_mailer_paths.rb']
+              'patch_mailer_paths.rb',
+              'alaveteli_text_masker.rb']
   require File.expand_path "../#{patch}", __FILE__
 end
 


### PR DESCRIPTION
Commands timeout after 5 minutes so memory will be released.

Patch core Alaveteli for now will observe how this works and then
hopefully merge into core later.

See: https://github.com/mysociety/sysadmin/issues/1390

This change should be loaded correctly, can be checked by an pry console:
```
[1] pry(main)> show-source AlaveteliTextMasker.uncompress_pdf

From: /Users/gbp/Documents/mySociety/transparency/alaveteli/lib/themes/asktheeu-theme/lib/alaveteli_text_masker.rb @ line 6:
Owner: AlaveteliTextMasker
Visibility: private
Number of lines: 3

def uncompress_pdf(text)
  AlaveteliExternalCommand.run("pdftk", "-", "output", "-", "uncompress", :stdin_string => text, :timeout => 300)
end
```