### PR TITLE
Add patch to raw email for edge case issue

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -153,4 +153,18 @@ Rails.configuration.to_prepare do
 
   end
 
+  RawEmail.class_eval do
+
+    alias original_data data
+
+    def data
+      original_data.sub(/
+        ^(Date: [^\n]+\n)
+        \s+(To: [^\n]+\n)
+        \s+(From: [^\n]+)
+      /x, '\1\2\3')
+    end
+
+  end
+
 end


### PR DESCRIPTION
Fixes issue where spaces are included before some email headers.

See https://github.com/mysociety/alaveteli/issues/6853