### PR TITLE
Add no reply address

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -145,6 +145,10 @@ Rails.configuration.to_prepare do
     end
   end
 
+  ReplyToAddressValidator.invalid_reply_addresses = %w[
+    automated-notifications@nomail.ec.europa.eu
+  ]
+
   User.class_eval do
     validates :name,
               :on => :create,


### PR DESCRIPTION
Customise invalid_reply_addresses 

Adds a custom `invalid_reply_addresses` list to cover issues with
several EU authorities using a no-reply address to send acknowledgements [1].

[1] https://groups.google.com/a/mysociety.org/g/alaveteli/c/jq_TazcXamc/m/IMweQZ4hBwAJ